### PR TITLE
Make triggerWheel not use enum + refactors

### DIFF
--- a/src/main/java/frc/robot/subsystems/Indexer.java
+++ b/src/main/java/frc/robot/subsystems/Indexer.java
@@ -48,7 +48,7 @@ public class Indexer extends SubsystemBase {
         return setSpeedCommand(IntakeConstants.TRAP_TRIGGER_WHEEL_SPEED);
     }
 
-    public Command stopCommand() {
+    public Command stop() {
         return setSpeedCommand(IntakeConstants.STOP_SPEED);
     }
 }


### PR DESCRIPTION
This relates to #30 
This is mostly preference, but I think it will be better overall to keep the code from not being overcomplex. If we want to check if it is clockwise or counterclockwise we can just check the sign of the desired speed.